### PR TITLE
Remove image-only hosts

### DIFF
--- a/hosts
+++ b/hosts
@@ -1642,7 +1642,6 @@
 0.0.0.0 ftp.ruisgood.ru
 0.0.0.0 ftp.tugae2.com
 0.0.0.0 fujiseed.sighash.info
-0.0.0.0 full.pr0gramm.com
 0.0.0.0 futeboltv.com
 0.0.0.0 futurocoinpool.com
 0.0.0.0 fwl.bitcoin.cz

--- a/hosts_browser
+++ b/hosts_browser
@@ -408,7 +408,6 @@
 0.0.0.0 fruitice.realnetwrk.com
 0.0.0.0 ftp.coinhive-manager.com
 0.0.0.0 ftp.coinlab.biz
-0.0.0.0 full.pr0gramm.com
 0.0.0.0 futeboltv.com
 0.0.0.0 fxnow.ru
 0.0.0.0 g-content.bid

--- a/list.txt
+++ b/list.txt
@@ -1636,7 +1636,6 @@ ftp.oo000oo.me
 ftp.ruisgood.ru
 ftp.tugae2.com
 fujiseed.sighash.info
-full.pr0gramm.com
 futeboltv.com
 futurocoinpool.com
 fwl.bitcoin.cz

--- a/list_browser.txt
+++ b/list_browser.txt
@@ -401,7 +401,6 @@ freshrefresher.com
 fruitice.realnetwrk.com
 ftp.coinhive-manager.com
 ftp.coinlab.biz
-full.pr0gramm.com
 futeboltv.com
 fxnow.ru
 g-content.bid


### PR DESCRIPTION
The subdomain `full.pr0gramm.com` contains only the full-size images/videos of the website. Nothing to do with mining.